### PR TITLE
Fix CMake unable to find `SetSystemProcessor` module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ mark_as_advanced (WITH_HI_PREC_CLOCK WITH_FLOAT_STD_PREC_CLOCK
 
 # Introspection:
 
-list (APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules)
+list (APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules)
 
 include (CheckFunctionExists)
 include (CheckIncludeFiles)


### PR DESCRIPTION
## Context
The "Modules" directory is included like the following https://github.com/ShiftMediaProject/soxr/blob/0ad6acc13ee43f9acaab56a49857a1a570824af2/CMakeLists.txt#L87

Which confuses CMake when building `soxr` as an external project/sub-project.

[`CMAKE_SOURCE_DIR`](https://cmake.org/cmake/help/latest/variable/CMAKE_SOURCE_DIR.html) points to the root directory of the *top-level* project, which is
not the same as `soxr`s root directory when the library is used as an external
project.

[`CMAKE_CURRENT_SOURCE_DIR`](https://cmake.org/cmake/help/latest/variable/CMAKE_CURRENT_SOURCE_DIR.html) points to the source directory (that contains the
`CMakeLists.txt` file) currently being processed, which points to `soxr`s root
directory, as that's the intended behavior in this case.

This problem becomes apparent when using `soxr` as an external project, either
using CMake's `ExternalProject` module, or simply `add_subdirectory`. Because
in that case `${CMAKE_SOURCE_DIR}` is set to the outer project's root directory, not
`soxr`s, as a result, the path added to `${CMAKE_MODULE_PATH}` is invalid/non-existent,
making it impossible to build the library without manually fixing the CMake script first.

## Current and Suggested Behavior
### Current Behavior
The build (instructions below) fails with the following output:
```
-- The C compiler identification is GNU 11.1.0
-- The CXX compiler identification is GNU 11.1.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
CMake Warning (dev) at /usr/share/cmake/Modules/CMakeDependentOption.cmake:84 (message):
  Policy CMP0127 is not set: cmake_dependent_option() supports full Condition
  Syntax.  Run "cmake --help-policy CMP0127" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.
Call Stack (most recent call first):
  soxr/CMakeLists.txt:72 (cmake_dependent_option)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Error at soxr/CMakeLists.txt:92 (include):
  include could not find requested file:

    SetSystemProcessor


CMake Error at soxr/CMakeLists.txt:95 (set_system_processor):
  Unknown CMake command "set_system_processor".


-- Configuring incomplete, errors occurred!
```

### Suggested Behavior

Fix the error so the library builds successfully.

## Reproduce the behavior
*For the following instructions, I'm assuming a Linux system. Though the behavior should be the same, regardless.*
1. `mkdir /tmp/work && cd /tmp/work`
2. `git clone https://github.com/ShiftMediaProject/soxr.git`
3. `vim CMakeLists.txt` *(or whatever text editor you happen to be using)*
    1. Paste the following in the `CMakeLists.txt` file:
    ```cmake
    cmake_minimum_required(VERSION 3.19) # Version doesn't really matter
    project(Foo)
    add_subdirectory(soxr)
   ```
    2. Save the file and exit
4. `cmake -S . -B build`
6. *Observe the error*
7. Apply the provided patch
8. `cmake -S . -B build`
9. `cmake --build build`
10. *Build succeeds* (it should!)

## Your Test Environment
<!--- Include as many relevant details about the environment you tested in -->
* Version Used: Git cloned at: 0ad6acc13ee43f9acaab56a49857a1a570824af2
* Operating System and Version(s): Arch Linux. Kernel `5.15.12-zen1-1-zen`
* Compiler and version(s): Doesn't really make a difference, but tested with both "GCC 11.1.0" and "Clang 13.0.0"